### PR TITLE
【Feat】输出文件名与输入文件名一致&返回文件名，便于代码复用与集成

### DIFF
--- a/ncmdump.py
+++ b/ncmdump.py
@@ -61,7 +61,7 @@ def dump(file_path):
     image_size = f.read(4)
     image_size = struct.unpack('<I', bytes(image_size))[0]
     image_data = f.read(image_size)
-    file_name = meta_data['musicName'] + '.' + meta_data['format']
+    file_name = f.name.split("/")[-1].split(".ncm")[0] + '.' + meta_data['format']
     m = open(os.path.join(os.path.split(file_path)[0], file_name), 'wb')
     chunk = bytearray()
     while True:
@@ -75,6 +75,7 @@ def dump(file_path):
         m.write(chunk)
     m.close()
     f.close()
+    return file_name
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
我将您的代码应用在了我的项目（ https://github.com/LuRenJiasWorld/NcmDump-Online ）中（已注明作者与来源），在使用您项目的时候，发现了两个细节上的小问题，故做出改进，便于更好的与其他项目集成：
1. 使输出的文件名与输入的文件名保持一致
2. 返回值为输出的文件名，便于调用dump()函数的时候获得输出文件路径

> 如果您觉得这两点改动恰当，可以Merge到您的项目中来。